### PR TITLE
Fix OpenStruct

### DIFF
--- a/lib/ext/ostruct.rb
+++ b/lib/ext/ostruct.rb
@@ -1,0 +1,5 @@
+require "ostruct"
+
+class OpenStruct
+  attr_reader :table
+end

--- a/test/ext/ostruct_test.rb
+++ b/test/ext/ostruct_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class ::Fathom::OpenStructTest < ::ActiveSupport::TestCase
+
+  def test_table
+    @subject = OpenStruct.new({ :foo => :bar })
+    expected = { :foo => :bar }
+    assert_equal(expected, @subject.table)
+  end
+end


### PR DESCRIPTION
The underlying table is not exposed in the standard library.
I'd rather have an easy way to store meta information and
extract the hash as well.
